### PR TITLE
Avoid empty string as a initial value DatePicker

### DIFF
--- a/es/components/DatePicker.js
+++ b/es/components/DatePicker.js
@@ -23,7 +23,7 @@ var MonthPicker = _datePicker.default.MonthPicker;
 
 var valueToMoment = function valueToMoment(value, dateFormat) {
   if (value === undefined || value === null || value === "") {
-    return value;
+    return undefined;
   }
 
   return (0, _moment.default)(value, dateFormat);

--- a/lib/components/DatePicker.js
+++ b/lib/components/DatePicker.js
@@ -23,7 +23,7 @@ var MonthPicker = _datePicker.default.MonthPicker;
 
 var valueToMoment = function valueToMoment(value, dateFormat) {
   if (value === undefined || value === null || value === "") {
-    return value;
+    return undefined;
   }
 
   return (0, _moment.default)(value, dateFormat);

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -7,7 +7,7 @@ const MonthPicker = DatePicker.MonthPicker;
 
 const valueToMoment = (value, dateFormat) => {
   if (value === undefined || value === null || value === "") {
-    return value;
+    return undefined;
   }
   return moment(value, dateFormat);
 };


### PR DESCRIPTION
Tested with the newest version of Ant-design (**v3.19.2**).

#### Background
DatePicker was receiving an empty string as an initial value if it was not set or it was a **null**, **undefined** or an **empty string** value in the redux form.
I updated `valueToMoment` method that parses value to return **undefined** to avoid passing an empty string.

<img width="748" alt="Screenshot 2019-06-22 at 13 02 35" src="https://user-images.githubusercontent.com/2499935/59963662-29726180-94ee-11e9-9b69-eaf460e3670b.png">