### PR TITLE
Remove min-width 200px from SelectField

### DIFF
--- a/src/components/SelectField.js
+++ b/src/components/SelectField.js
@@ -15,7 +15,6 @@ const selectFieldMap = customMap(
         onChange: value => value === undefined ? onChange(null) : onChange(value),
         dropdownMatchSelectWidth: true,
         value,
-        style: { minWidth: 200 }
     };
   }
 );


### PR DESCRIPTION
This hardcoded style is preventing us from using the SelectField in a flexible manner.